### PR TITLE
feat: Add support for roles when creating a bearer token

### DIFF
--- a/lib/createBearerToken.ts
+++ b/lib/createBearerToken.ts
@@ -13,6 +13,7 @@ export interface CreateTokenOptions {
   clientID: string;
   authServerURL: string;
   audience?: string | string[];
+  roles?: string[];
 }
 
 const createBearerToken = (options: CreateTokenOptions): string => {
@@ -29,6 +30,9 @@ const createBearerToken = (options: CreateTokenOptions): string => {
       sub: options.user.profile.id,
       azp: options.clientID,
       session_state: uuidv4(),
+      ...(options.roles && {
+        resource_access: { [options.clientID]: { roles: options.roles } },
+      }),
     },
     options.key.toPEM(true),
     {

--- a/lib/instance.ts
+++ b/lib/instance.ts
@@ -25,6 +25,7 @@ export interface MockInstanceParams {
 
 export interface BearerTokenOptions {
   audience?: string | string[];
+  roles?: string[];
 }
 
 class MockInstance {
@@ -67,6 +68,7 @@ class MockInstance {
       clientID: this.params.clientID,
       authServerURL: this.params.authServerURL,
       audience: options.audience,
+      roles: options.roles,
     });
   }
 }

--- a/tests/createBearerToken.spec.ts
+++ b/tests/createBearerToken.spec.ts
@@ -34,6 +34,7 @@ describe("createBearerToken", () => {
       clientID: "client",
       authServerURL: "https://example.com",
       audience: "test",
+      roles: ["admin"],
     };
 
     const token = createBearerToken(createTokenOptions);
@@ -44,6 +45,9 @@ describe("createBearerToken", () => {
     expect(decodedToken.payload.typ).toBe("Bearer");
     expect(decodedToken.payload.azp).toBe(createTokenOptions.clientID);
     expect(decodedToken.payload.aud).toBe(createTokenOptions.audience);
+    expect(decodedToken.payload.resource_access).toStrictEqual({
+      client: { roles: ["admin"] },
+    });
     expect(decodedToken.payload.iss).toBe(
       `${createTokenOptions.authServerURL}/realms/${createTokenOptions.realm}`
     );


### PR DESCRIPTION
This would close #6, and the way its implemented is by passing the roles when creating a bearer token

Please let me know if you see this being implemented a different way